### PR TITLE
Updated markdown and pdfdom versions for Laravel 5.5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "PDF module for laralum",
     "require": {
 	"laralum/laralum": "1.*",
-        "barryvdh/laravel-dompdf" : "0.8",
-        "graham-campbell/markdown": "^7.0"
+        "barryvdh/laravel-dompdf" : "^0.8",
+        "graham-campbell/markdown": "^8.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Updated the versions on `graham-campbell/markdown` and `barryvdh/laravel-dompdf` to pull the latest versions allowing it to be used with Laravel 5.5.